### PR TITLE
fix(aasa): correct prod App ID (com.mkg.sayar, no .prod suffix)

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -6,7 +6,7 @@
         "appIDs": [
           "Q9ARVAPAG3.com.mkg.sayar.dev",
           "Q9ARVAPAG3.com.mkg.sayar.uat",
-          "Q9ARVAPAG3.com.mkg.sayar.prod"
+          "Q9ARVAPAG3.com.mkg.sayar"
         ],
         "paths": ["*"]
       }


### PR DESCRIPTION
## Summary
Hosted AASA listed the prod app as `Q9ARVAPAG3.com.mkg.sayar.prod`, but Sayar's prod bundle id is `com.mkg.sayar` (only Dev/UAT carry `.dev`/`.uat`) — so universal links never validated for the App Store build. Fixed to `Q9ARVAPAG3.com.mkg.sayar`; Dev/UAT unchanged.

Verified `npm run build` emits `out/.well-known/apple-app-site-association`, so after deploy it serves at `https://mkemalgokce.github.io/.well-known/apple-app-site-association`.

Note: `paths: ["*"]` makes every link on the domain open the app. If this is a portfolio site, consider scoping to `/categories/*`, `/statistics/*`, `/history/*`. Left as-is (your call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)