### PR TITLE
fix(aasa): restore prod App ID suffix (com.mkg.sayar.prod)

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -6,7 +6,7 @@
         "appIDs": [
           "Q9ARVAPAG3.com.mkg.sayar.dev",
           "Q9ARVAPAG3.com.mkg.sayar.uat",
-          "Q9ARVAPAG3.com.mkg.sayar"
+          "Q9ARVAPAG3.com.mkg.sayar.prod"
         ],
         "paths": ["*"]
       }


### PR DESCRIPTION
The app is registered in App Store Connect as `com.mkg.sayar.prod`. PR #5 dropped the `.prod` suffix (wrong assumption); restore it so prod universal links validate. Dev/UAT unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)